### PR TITLE
hexagon-arch-tests: use PL011 UART address 0x10000000

### DIFF
--- a/hexagon-arch-tests/src/lib.rs
+++ b/hexagon-arch-tests/src/lib.rs
@@ -186,7 +186,7 @@ pub fn putc(c: u8) {
 /// UART transmit data register address.
 /// Set this to match your target machine's UART base.
 #[cfg(feature = "uart")]
-pub const UART_TX: u32 = 0xD800_0000;
+pub const UART_TX: u32 = 0x1000_0000;
 
 /// Write a single byte to the console via UART MMIO.
 #[cfg(feature = "uart")]


### PR DESCRIPTION
Update the UART transmit register address to match the standard PL011 base used by QEMU's hexagon system emulation.