### PR TITLE
standalone_systests: drop hardcoded CWD path check in semihost

### DIFF
--- a/standalone_systests/src/semihost.c
+++ b/standalone_systests/src/semihost.c
@@ -99,24 +99,6 @@ static uint32_t ret, err, args[4];
 #define DIRECT_SWI(...) \
     GET_MACRO_3(__VA_ARGS__, DIRECT_SWI2, DIRECT_SWI1, DIRECT_SWI0)(__VA_ARGS__)
 
-#define is_path_sep(C) ((C) == '/' || (C) == '\\')
-
-static int path_ends_with(const char *str, const char *suffix)
-{
-    const char *str_cursor = str + strlen(str) - 1;
-    const char *suffix_cursor = suffix + strlen(suffix) - 1;
-    while (str_cursor >= str && suffix_cursor >= suffix) {
-        /* is_path_sep handles the semihosting-on-Windows case */
-        if (*str_cursor != *suffix_cursor &&
-            !(is_path_sep(*str_cursor) && is_path_sep(*suffix_cursor))) {
-            return 0;
-        }
-        str_cursor--;
-        suffix_cursor--;
-    }
-    return 1;
-}
-
 /*
  * This must match the caller's definition, it would be in the
  * caller's angel.h or equivalent header.
@@ -152,9 +134,8 @@ int main(int argc, char **argv)
     assert(!ret && !strcmp(buf, argv_concat));
 
     /* GETCWD */
-    const char *expected_cwd = "tests/tcg/hexagon-softmmu";
     SWI(HEX_SYS_GETCWD, buf, sizeof(buf));
-    assert(ret && path_ends_with(buf, expected_cwd));
+    assert(ret);
 
     /* TMPNAM */
     char fname[4096];


### PR DESCRIPTION
The semihost test asserted that GETCWD returns a path ending in "tests/tcg/hexagon-softmmu" -- a holdover from when the test was run from the QEMU source tree by the TCG harness.  After moving the test to QEMU's functional-test framework, the binary runs from a per-test workdir and the suffix check fails for no good reason.

The check was a sanity check on where the test ran, not a validation of GETCWD itself; remove it.  The remaining assert on `ret` still verifies that GETCWD succeeded.

Remove the now-unused `path_ends_with` helper and its `is_path_sep` macro along with it.