### PR TITLE
test_sys_regs: gate imask_readwrite on ISA version from REV

### DIFF
--- a/hexagon-arch-tests/src/bin/test_sys_regs.rs
+++ b/hexagon-arch-tests/src/bin/test_sys_regs.rs
@@ -47,12 +47,36 @@ fn test_syscfg() {
 }
 
 /// Read/write IMASK: write pattern, read back, verify match, then restore.
+///
+/// IMASK's full-register writability depends on the ISA version (read from
+/// REV[7:0]):
+///   - Prior to v65: unsupported, rejected outright.
+///   - v65 through v80: bits 31:16 are architecturally read-only, so a
+///     write only affects bits 15:0.
+///   - v81 and later: all 32 bits are read/write.
 fn test_imask_readwrite() {
+    let isa = isa_version();
+    if isa < ISA_V65 {
+        println!(
+            "FAIL: ISA version 0x{:02x} is older than v65 (0x{:02x}); \
+             imask_readwrite is unsupported on this target",
+            isa, ISA_V65
+        );
+        record_error();
+        return;
+    }
+
     let saved = read_imask();
     let pattern: u32 = 0xAAAA_0000;
     write_imask(pattern);
     let readback = read_imask();
-    check32!(readback, pattern);
+    if isa >= ISA_V81 {
+        // v81+: IMASK bits 31:0 are all read/write.
+        check32!(readback, pattern);
+    } else {
+        // v65..v80: bits 31:16 are read-only and ignore writes.
+        check32!(readback, pattern & 0x0000_FFFF);
+    }
     // Restore
     write_imask(saved);
 }

--- a/hexagon-arch-tests/src/lib.rs
+++ b/hexagon-arch-tests/src/lib.rs
@@ -104,6 +104,15 @@ pub const CCR_GRE: u32 = 1 << CCR_GRE_BIT;
 pub const CCR_VV1: u32 = 1 << CCR_VV1_BIT;
 
 // ---------------------------------------------------------------------------
+// REV register / ISA version
+// ---------------------------------------------------------------------------
+// REV[7:0] holds the ISA version byte, encoded so that architecture vNN
+// reads back as the literal byte 0xNN (e.g. v81 -> 0x81, v68 -> 0x68).
+pub const REV_ISA_MASK: u32 = 0xFF;
+pub const ISA_V65: u32 = 0x65;
+pub const ISA_V81: u32 = 0x81;
+
+// ---------------------------------------------------------------------------
 // Exception cause codes
 // ---------------------------------------------------------------------------
 pub const CAUSE_PRECISE_BUS_ERROR: u32 = 0x01;
@@ -534,6 +543,21 @@ pub fn read_cfgbase() -> u32 {
         asm!("{0} = cfgbase", out(reg) val, options(nomem, nostack));
     }
     val
+}
+
+#[inline(always)]
+pub fn read_rev() -> u32 {
+    let val: u32;
+    unsafe {
+        asm!("{0} = rev", out(reg) val, options(nomem, nostack));
+    }
+    val
+}
+
+/// Extract the ISA version byte (REV[7:0]) from the REV register.
+#[inline(always)]
+pub fn isa_version() -> u32 {
+    read_rev() & REV_ISA_MASK
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
imask's full-register writability is architecturally dependent on the ISA version: prior to v81, bits 31:16 are read-only.

v81 and later allow the full 32 bits to be written.  The previous test assumed unconditional full-register writability, which only holds on v81+.

Anything prior to v65 is rejected as unsupported - we don't have QEMU support for pre-v65 yet, so it's not as interesting to test with.