### PR TITLE
Remove changelog

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -410,26 +410,6 @@ jobs:
         id: get_tag
         run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Generate changelog
-        id: changelog
-        run: |
-          # Get the previous tag
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 ${{ steps.get_tag.outputs.TAG_NAME }}^ 2>/dev/null || echo "")
-
-          # Generate changelog
-          if [ -z "$PREVIOUS_TAG" ]; then
-            echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-            echo "Initial release" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          else
-            echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-            echo "## Changes since $PREVIOUS_TAG" >> $GITHUB_OUTPUT
-            echo "" >> $GITHUB_OUTPUT
-            git log $PREVIOUS_TAG..${{ steps.get_tag.outputs.TAG_NAME }} --pretty=format:"- %s (%h)" >> $GITHUB_OUTPUT
-            echo "" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
-
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
The changelog steps in the build/test were flagged as risking code injection.  We don't need the changelog for anything, it is simplest to just remove it.

```
Run "${GITHUB_ACTION_PATH}/action.sh"
   INFO zizmor: 🌈 zizmor v1.25.2
   INFO audit: zizmor: 🌈 completed ./.github/dependabot.yaml
   INFO audit: zizmor: 🌈 completed ./.github/workflows/build-tests.yml
   INFO audit: zizmor: 🌈 completed ./.github/workflows/qcom-preflight-checks.yml
   INFO audit: zizmor: 🌈 completed ./.github/workflows/stale-issues.yaml
  Error: build-tests.yml:417: code injection via template expansion: may expand into attacker-controllable code
  Error: build-tests.yml:428: code injection via template expansion: may expand into attacker-controllable code
```